### PR TITLE
Fixes for /basic/page/home crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This starter kit uses Next.js 16, which includes React 19 and all the latest fea
 **Building with AI:** [Agent Skills](https://www.datocms.com/docs/agent-skills) turn coding assistants (Claude Code, Cursor) into expert DatoCMS developers, with full read/write via the auto-installed CLI. No local terminal? Use the [MCP Server](https://www.datocms.com/docs/mcp-server) instead.
 
 **Talking to DatoCMS from code:**
+
 - [Content Delivery API](https://www.datocms.com/docs/content-delivery-api) (CDA) — the fast, read-only GraphQL API your website/app uses to **fetch** published content.
 - [Content Management API](https://www.datocms.com/docs/content-management-api) (CMA) — the REST API for **creating and updating** content, models, and project settings (think scripts, migrations, integrations).
 - [CLI](https://www.datocms.com/docs/scripting-migrations/installing-the-cli) — terminal tool for schema migrations and importing from Contentful/WordPress.
@@ -171,6 +172,5 @@ This starter kit uses Next.js 16, which includes React 19 and all the latest fea
 **Framework guides:** end-to-end recipes for fetching content, rendering Structured Text, optimizing images/video, handling SEO, and setting up live preview with visual editing in [Next.js](https://www.datocms.com/docs/next-js), [Nuxt](https://www.datocms.com/docs/nuxt), [Svelte](https://www.datocms.com/docs/svelte), and [Astro](https://www.datocms.com/docs/astro).
 
 **Want a head start?** Browse our [starter projects](https://www.datocms.com/marketplace/starters) — ready-to-deploy example sites for popular frameworks.
-
 
 <!--datocms-autoinclude-footer end-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@datocms/cda-client": "^0.2.10",
         "@datocms/cma-client": "^5.4.18",
+        "@mux/mux-player-react": "^3.13.0",
         "@types/highlight.js": "^10.1.0",
         "datocms-plugin-sdk": "^2.1.5",
         "datocms-react-ui": "^2.1.5",
@@ -282,6 +283,7 @@
       "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-5.4.18.tgz",
       "integrity": "sha512-SlH1ovj17ekOZ8Gl12fydhv0VBQPOLiiwa/fPIw79Lj4TCupB97KoPue61SYk+a95p2+kyWzFpkASw+5paYJLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@datocms/rest-client-utils": "^5.4.9",
         "datocms-structured-text-utils": "^5.1.4",
@@ -306,6 +308,7 @@
       "integrity": "sha512-k5/O0qS270jdqM5yzyBPPwh4YUCzSGLFNsoipmEckiJOSFIQ8AkSJlEZI+FykSMAr3zir4od1Ywz+RS8bEwIww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@datocms/cma-client": "^5.4.18",
         "@datocms/rest-client-utils": "^5.4.9",
@@ -367,6 +370,7 @@
       "integrity": "sha512-I2szN/bgaQXZRvwP/PXExh0MTtddisz5y0ShG3qrEJYLn/SFACLVyhpe4lmMqJReB63smGTCnFdDaKBBeTUbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.0"
       }
@@ -1919,40 +1923,35 @@
       "license": "MIT"
     },
     "node_modules/@mux/mux-data-google-ima": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
-      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.17.tgz",
+      "integrity": "sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "mux-embed": "5.9.0"
+        "mux-embed": "5.18.1"
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.9.2.tgz",
-      "integrity": "sha512-QK7y1fYoxR2XHc5GO2owfpClsb94hN7k+bTNKp2+oolTAfc2PT1ygGVDq7RFUPz6VNTiZUBvDlRn62CylfxTFw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.0.tgz",
+      "integrity": "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@mux/mux-video": "0.28.2",
-        "@mux/playback-core": "0.31.4",
-        "media-chrome": "~4.16.1",
+        "@mux/mux-video": "0.31.0",
+        "@mux/playback-core": "0.35.0",
+        "media-chrome": "~4.19.0",
         "player.style": "^0.3.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.9.2.tgz",
-      "integrity": "sha512-BzTQEpjNdxyL2hlbZaUKZmSdw7m6YS00zzmrnuBAxnFDZ3m9z45lo3GrtRmnuy3v30gO0faQ1S34BTRLxGNRLQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.0.tgz",
+      "integrity": "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==",
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
-        "@mux/mux-player": "3.9.2",
-        "@mux/playback-core": "0.31.4",
+        "@mux/mux-player": "3.13.0",
+        "@mux/playback-core": "0.35.0",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
@@ -1970,30 +1969,26 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.28.2.tgz",
-      "integrity": "sha512-+ij1EOI7Tx2zYAzIXAIbZJzxqISmIIz3f7aE/R5JFt9dcPxCNIN6/iXGJikiD1JQ4S3T7Mco8bHXaf1S0CJbIQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.0.tgz",
+      "integrity": "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@mux/mux-data-google-ima": "0.2.8",
-        "@mux/playback-core": "0.31.4",
-        "castable-video": "~1.1.11",
-        "custom-media-element": "~1.4.5",
-        "media-tracks": "~0.3.4"
+        "@mux/mux-data-google-ima": "^0.3.4",
+        "@mux/playback-core": "0.35.0",
+        "castable-video": "~1.1.13",
+        "custom-media-element": "~1.4.6",
+        "media-tracks": "~0.3.5"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.4.tgz",
-      "integrity": "sha512-qQrNAAdJ7vjr1XEObE1hOUmuYngk/fjwmtYhpzkX4jJZwUC8I0rHjeFv7LXuCQD1D/mYJlWEpuyA0gPd6Y2eQw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.0.tgz",
+      "integrity": "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "hls.js": "~1.6.15",
-        "mux-embed": "^5.8.3"
+        "mux-embed": "^5.16.1"
       }
     },
     "node_modules/@next/env": {
@@ -2377,6 +2372,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2398,6 +2394,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2825,14 +2822,12 @@
       ]
     },
     "node_modules/castable-video": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.11.tgz",
-      "integrity": "sha512-LCRTK6oe7SB1SiUQFzZCo6D6gcEzijqBTVIuj3smKpQdesXM18QTbCVqWgh9MfOeQgTx/i9ji5jGcdqNPeWg2g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.16.tgz",
+      "integrity": "sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "custom-media-element": "~1.4.5"
+        "custom-media-element": "~1.4.6"
       }
     },
     "node_modules/ce-la-react": {
@@ -2840,8 +2835,6 @@
       "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
       "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "react": ">=17.0.0"
       }
@@ -3133,12 +3126,10 @@
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
-      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
+      "integrity": "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==",
+      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4255,6 +4246,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -4371,12 +4363,10 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
-      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -5135,23 +5125,19 @@
       }
     },
     "node_modules/media-chrome": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.16.1.tgz",
-      "integrity": "sha512-qtFlsy0lNDVCyVo//ZCAfRPKwgehfOYp6rThZzDUuZ5ypv41yqUfAxK+P9TOs+XSVWXATPTT2WRV0fbW0BH4vQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.1.tgz",
+      "integrity": "sha512-1+x2l0mNulHKZN0lBxGJwJ+TV2W/KzLjaAd//UCGZz8GE5O5YNafFskWTcv/D6Ty0d9drX9SSfimOzGwob8eVQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "ce-la-react": "^0.3.2"
       }
     },
     "node_modules/media-tracks": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.4.tgz",
-      "integrity": "sha512-5SUElzGMYXA7bcyZBL1YzLTxH9Iyw1AeYNJxzByqbestrrtB0F3wfiWUr7aROpwodO4fwnxOt78Xjb3o3ONNQg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.5.tgz",
+      "integrity": "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "6.0.0",
@@ -5248,12 +5234,10 @@
       }
     },
     "node_modules/mux-embed": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
-      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.18.1.tgz",
+      "integrity": "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7188,6 +7172,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7532,6 +7517,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7544,8 +7530,6 @@
       "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
       "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "workspaces": [
         ".",
         "site",
@@ -7562,8 +7546,6 @@
       "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
       "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "ce-la-react": "^0.3.0"
       }
@@ -7624,6 +7606,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7667,6 +7650,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7703,6 +7687,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8681,6 +8666,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9212,6 +9198,7 @@
       "version": "5.4.18",
       "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-5.4.18.tgz",
       "integrity": "sha512-SlH1ovj17ekOZ8Gl12fydhv0VBQPOLiiwa/fPIw79Lj4TCupB97KoPue61SYk+a95p2+kyWzFpkASw+5paYJLg==",
+      "peer": true,
       "requires": {
         "@datocms/rest-client-utils": "^5.4.9",
         "datocms-structured-text-utils": "^5.1.4",
@@ -9230,6 +9217,7 @@
       "resolved": "https://registry.npmjs.org/@datocms/cma-client-node/-/cma-client-node-5.4.18.tgz",
       "integrity": "sha512-k5/O0qS270jdqM5yzyBPPwh4YUCzSGLFNsoipmEckiJOSFIQ8AkSJlEZI+FykSMAr3zir4od1Ywz+RS8bEwIww==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@datocms/cma-client": "^5.4.18",
         "@datocms/rest-client-utils": "^5.4.9",
@@ -9275,6 +9263,7 @@
       "resolved": "https://registry.npmjs.org/@datocms/rest-api-reference/-/rest-api-reference-5.4.15.tgz",
       "integrity": "sha512-I2szN/bgaQXZRvwP/PXExh0MTtddisz5y0ShG3qrEJYLn/SFACLVyhpe4lmMqJReB63smGTCnFdDaKBBeTUbcw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^11.7.0"
       }
@@ -10041,63 +10030,54 @@
       "dev": true
     },
     "@mux/mux-data-google-ima": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
-      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
-      "optional": true,
-      "peer": true,
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.17.tgz",
+      "integrity": "sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==",
       "requires": {
-        "mux-embed": "5.9.0"
+        "mux-embed": "5.18.1"
       }
     },
     "@mux/mux-player": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.9.2.tgz",
-      "integrity": "sha512-QK7y1fYoxR2XHc5GO2owfpClsb94hN7k+bTNKp2+oolTAfc2PT1ygGVDq7RFUPz6VNTiZUBvDlRn62CylfxTFw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.0.tgz",
+      "integrity": "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==",
       "requires": {
-        "@mux/mux-video": "0.28.2",
-        "@mux/playback-core": "0.31.4",
-        "media-chrome": "~4.16.1",
+        "@mux/mux-video": "0.31.0",
+        "@mux/playback-core": "0.35.0",
+        "media-chrome": "~4.19.0",
         "player.style": "^0.3.0"
       }
     },
     "@mux/mux-player-react": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.9.2.tgz",
-      "integrity": "sha512-BzTQEpjNdxyL2hlbZaUKZmSdw7m6YS00zzmrnuBAxnFDZ3m9z45lo3GrtRmnuy3v30gO0faQ1S34BTRLxGNRLQ==",
-      "optional": true,
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.0.tgz",
+      "integrity": "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==",
       "peer": true,
       "requires": {
-        "@mux/mux-player": "3.9.2",
-        "@mux/playback-core": "0.31.4",
+        "@mux/mux-player": "3.13.0",
+        "@mux/playback-core": "0.35.0",
         "prop-types": "^15.8.1"
       }
     },
     "@mux/mux-video": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.28.2.tgz",
-      "integrity": "sha512-+ij1EOI7Tx2zYAzIXAIbZJzxqISmIIz3f7aE/R5JFt9dcPxCNIN6/iXGJikiD1JQ4S3T7Mco8bHXaf1S0CJbIQ==",
-      "optional": true,
-      "peer": true,
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.0.tgz",
+      "integrity": "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==",
       "requires": {
-        "@mux/mux-data-google-ima": "0.2.8",
-        "@mux/playback-core": "0.31.4",
-        "castable-video": "~1.1.11",
-        "custom-media-element": "~1.4.5",
-        "media-tracks": "~0.3.4"
+        "@mux/mux-data-google-ima": "^0.3.4",
+        "@mux/playback-core": "0.35.0",
+        "castable-video": "~1.1.13",
+        "custom-media-element": "~1.4.6",
+        "media-tracks": "~0.3.5"
       }
     },
     "@mux/playback-core": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.4.tgz",
-      "integrity": "sha512-qQrNAAdJ7vjr1XEObE1hOUmuYngk/fjwmtYhpzkX4jJZwUC8I0rHjeFv7LXuCQD1D/mYJlWEpuyA0gPd6Y2eQw==",
-      "optional": true,
-      "peer": true,
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.0.tgz",
+      "integrity": "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==",
       "requires": {
         "hls.js": "~1.6.15",
-        "mux-embed": "^5.8.3"
+        "mux-embed": "^5.16.1"
       }
     },
     "@next/env": {
@@ -10341,6 +10321,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~7.16.0"
       }
@@ -10359,6 +10340,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "peer": true,
       "requires": {
         "csstype": "^3.2.2"
       }
@@ -10637,21 +10619,17 @@
       "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg=="
     },
     "castable-video": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.11.tgz",
-      "integrity": "sha512-LCRTK6oe7SB1SiUQFzZCo6D6gcEzijqBTVIuj3smKpQdesXM18QTbCVqWgh9MfOeQgTx/i9ji5jGcdqNPeWg2g==",
-      "optional": true,
-      "peer": true,
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.16.tgz",
+      "integrity": "sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==",
       "requires": {
-        "custom-media-element": "~1.4.5"
+        "custom-media-element": "~1.4.6"
       }
     },
     "ce-la-react": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
       "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
-      "optional": true,
-      "peer": true,
       "requires": {}
     },
     "chalk": {
@@ -10859,11 +10837,9 @@
       "dev": true
     },
     "custom-media-element": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
-      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
-      "optional": true,
-      "peer": true
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
+      "integrity": "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA=="
     },
     "data-view-buffer": {
       "version": "1.0.2",
@@ -11629,7 +11605,8 @@
     "graphql": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw=="
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "peer": true
     },
     "has-bigints": {
       "version": "1.1.0",
@@ -11695,11 +11672,9 @@
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
     },
     "hls.js": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
-      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
-      "optional": true,
-      "peer": true
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -12156,21 +12131,17 @@
       "dev": true
     },
     "media-chrome": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.16.1.tgz",
-      "integrity": "sha512-qtFlsy0lNDVCyVo//ZCAfRPKwgehfOYp6rThZzDUuZ5ypv41yqUfAxK+P9TOs+XSVWXATPTT2WRV0fbW0BH4vQ==",
-      "optional": true,
-      "peer": true,
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.1.tgz",
+      "integrity": "sha512-1+x2l0mNulHKZN0lBxGJwJ+TV2W/KzLjaAd//UCGZz8GE5O5YNafFskWTcv/D6Ty0d9drX9SSfimOzGwob8eVQ==",
       "requires": {
         "ce-la-react": "^0.3.2"
       }
     },
     "media-tracks": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.4.tgz",
-      "integrity": "sha512-5SUElzGMYXA7bcyZBL1YzLTxH9Iyw1AeYNJxzByqbestrrtB0F3wfiWUr7aROpwodO4fwnxOt78Xjb3o3ONNQg==",
-      "optional": true,
-      "peer": true
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.5.tgz",
+      "integrity": "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA=="
     },
     "memoize-one": {
       "version": "6.0.0",
@@ -12231,11 +12202,9 @@
       "dev": true
     },
     "mux-embed": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
-      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
-      "optional": true,
-      "peer": true
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.18.1.tgz",
+      "integrity": "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g=="
     },
     "nanoid": {
       "version": "3.3.11",
@@ -13441,7 +13410,8 @@
             "picomatch": {
               "version": "4.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "peer": true
             }
           }
         },
@@ -13689,14 +13659,13 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "player.style": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
       "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
-      "optional": true,
-      "peer": true,
       "requires": {
         "media-chrome": "~4.14.0"
       },
@@ -13705,8 +13674,6 @@
           "version": "4.14.0",
           "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
           "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "ce-la-react": "^0.3.0"
           }
@@ -13739,7 +13706,8 @@
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "proc-log": {
       "version": "4.2.0",
@@ -13766,7 +13734,8 @@
     "react": {
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
-      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw=="
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+      "peer": true
     },
     "react-datocms": {
       "version": "8.0.3",
@@ -13786,6 +13755,7 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+      "peer": true,
       "requires": {
         "scheduler": "^0.27.0"
       }
@@ -14421,7 +14391,8 @@
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@datocms/cda-client": "^0.2.10",
         "@datocms/cma-client": "^5.4.18",
+        "@datocms/content-link": "^0.3.21",
         "@mux/mux-player-react": "^3.13.0",
         "@types/highlight.js": "^10.1.0",
         "datocms-plugin-sdk": "^2.1.5",
@@ -346,9 +347,9 @@
       }
     },
     "node_modules/@datocms/content-link": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@datocms/content-link/-/content-link-0.3.20.tgz",
-      "integrity": "sha512-1VkFngKb1wC+XTjhjUPzamOg28LWeY1gpNJ+iuVj4GJq+RMOHg/r05VgOaQocICxgx0sAuuwywucI6tY3as04A==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@datocms/content-link/-/content-link-0.3.21.tgz",
+      "integrity": "sha512-gNNPeypTUlRSZmcKJBPSQijyOW7nIzWKqTGW+KuOf82NF9ALaklwhh7hC4+JaK8fLh7ArygXtjJsE1h8nA0kmA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9245,9 +9246,9 @@
       }
     },
     "@datocms/content-link": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@datocms/content-link/-/content-link-0.3.20.tgz",
-      "integrity": "sha512-1VkFngKb1wC+XTjhjUPzamOg28LWeY1gpNJ+iuVj4GJq+RMOHg/r05VgOaQocICxgx0sAuuwywucI6tY3as04A=="
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@datocms/content-link/-/content-link-0.3.21.tgz",
+      "integrity": "sha512-gNNPeypTUlRSZmcKJBPSQijyOW7nIzWKqTGW+KuOf82NF9ALaklwhh7hC4+JaK8fLh7ArygXtjJsE1h8nA0kmA=="
     },
     "@datocms/dashboard-client": {
       "version": "5.4.9",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "format": "npx prettier . --write",
     "prepare": "npx simple-git-hooks && npm run generate-schema && npm run generate-cma-types"
   },
-
   "dependencies": {
     "@datocms/cda-client": "^0.2.10",
     "@datocms/cma-client": "^5.4.18",
+    "@datocms/content-link": "^0.3.21",
     "@types/highlight.js": "^10.1.0",
     "datocms-plugin-sdk": "^2.1.5",
     "datocms-react-ui": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "npx prettier . --write",
     "prepare": "npx simple-git-hooks && npm run generate-schema && npm run generate-cma-types"
   },
+
   "dependencies": {
     "@datocms/cda-client": "^0.2.10",
     "@datocms/cma-client": "^5.4.18",
@@ -22,6 +23,7 @@
     "datocms-structured-text-utils": "^5.1.16",
     "gql.tada": "^1.9.0",
     "highlight.js": "^11.11.1",
+    "@mux/mux-player-react": "^3.13.0",
     "next": "^16",
     "node-html-parser": "^7.0.1",
     "react": "^19",

--- a/src/components/HeadingWithAnchorLink/index.tsx
+++ b/src/components/HeadingWithAnchorLink/index.tsx
@@ -1,7 +1,7 @@
 import { render as structuredTextToPlainText } from 'datocms-structured-text-to-plain-text';
 import type { Heading } from 'datocms-structured-text-utils';
 import type { ReactNode } from 'react';
-import { stripStega } from 'react-datocms';
+import { stripStega } from '@datocms/content-link';
 
 type Props = {
   node: Heading;


### PR DESCRIPTION
Two bugs were preventing pageload

1. We were not packaging `mux-player-react` and it was causing a crash
2. `stripStega()` doesn't work in server components until https://github.com/datocms/react-datocms/pull/120 is fixed, so we have to import it directly from content-link here
