### PR TITLE
Fix open redirect vulnerability in nextjs-starter-kit draft-mode handlers

### DIFF
--- a/src/app/api/draft-mode/disable/route.tsx
+++ b/src/app/api/draft-mode/disable/route.tsx
@@ -4,7 +4,7 @@ import type { NextRequest, NextResponse } from 'next/server';
 import {
   handleUnexpectedError,
   invalidRequestResponse,
-  isRelativeUrl,
+  isSafeRedirectUrl,
   makeDraftModeWorkWithinIframes,
 } from '../../utils';
 
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   try {
     // Avoid open redirect vulnerabilities
-    if (!isRelativeUrl(redirectTo)) {
+    if (!isSafeRedirectUrl(redirectTo, new URL(request.url))) {
       return invalidRequestResponse('URL must be relative!', 422);
     }
 

--- a/src/app/api/draft-mode/enable/route.tsx
+++ b/src/app/api/draft-mode/enable/route.tsx
@@ -4,7 +4,7 @@ import type { NextRequest, NextResponse } from 'next/server';
 import {
   handleUnexpectedError,
   invalidRequestResponse,
-  isRelativeUrl,
+  isSafeRedirectUrl,
   makeDraftModeWorkWithinIframes,
 } from '../../utils';
 
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     // Avoid open redirect vulnerabilities
-    if (!isRelativeUrl(redirectTo)) {
+    if (!isSafeRedirectUrl(redirectTo, new URL(request.url))) {
       return invalidRequestResponse('URL must be relative!', 422);
     }
 

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -100,19 +100,28 @@ export async function makeDraftModeWorkWithinIframes() {
   });
 }
 
-export function isRelativeUrl(path: string): boolean {
+/**
+ * Determine whether a user-supplied redirect target is safe to follow — i.e. it
+ * points to the same host as the current request.
+ *
+ * This guards against open-redirect attacks. A naive `url.startsWith('http')`
+ * check — and even a plain "is it a relative URL?" check — fails to catch
+ * protocol-relative targets like `//evil.com` or backslash variants like
+ * `/\evil.com`, both of which browsers happily send off-site.
+ *
+ * Instead, we resolve the candidate against the current request URL and require
+ * the resulting hostname to match. Relative paths (`/foo`, `/a?b=1#c`) resolve
+ * to the same host and pass; anything that escapes to another host — or fails to
+ * parse — is rejected. The scheme is irrelevant: we only compare hostnames.
+ */
+export function isSafeRedirectUrl(
+  candidate: string,
+  requestUrl: URL,
+): boolean {
   try {
-    // Try to create a URL object — if it succeeds without a base, it's absolute
-    new URL(path);
-    return false;
+    const target = new URL(candidate, requestUrl);
+    return target.hostname === requestUrl.hostname;
   } catch {
-    try {
-      // Verify it can be parsed as a relative URL by providing a base
-      new URL(path, 'http://example.com');
-      return true;
-    } catch {
-      // If both attempts fail, it's not a valid URL at all
-      return false;
-    }
+    return false;
   }
 }


### PR DESCRIPTION
Replace the vulnerable isRelativeUrl check with isSafeRedirectUrl, which properly validates that redirect targets resolve to the same hostname as the current request. This prevents open redirect attacks via protocol-relative URLs (//evil.com) and backslash variants (/\evil.com).